### PR TITLE
Improve discovery waiting and event fan-out

### DIFF
--- a/internal/adapters/discovery/discovery_manager_with_mocks_test.go
+++ b/internal/adapters/discovery/discovery_manager_with_mocks_test.go
@@ -2,7 +2,10 @@ package discovery
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -258,7 +261,7 @@ func TestDiscoveryManagerWithMockedProviders(t *testing.T) {
 		err := manager.Add(mockProvider)
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
 
 		err = manager.Start(ctx, "127.0.0.1", 8080, 9080)
@@ -306,6 +309,135 @@ func TestDiscoveryManagerWithMockedProviders(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("ManagerKeepsBroadcastingWhenSubscriberBacksUp", func(t *testing.T) {
+		metadata.ResetGlobalBootstrapMetadata()
+		logger := slog.Default()
+		manager := NewManager("test-node-stall", logger)
+
+		eventChan := make(chan ports.Event, 10)
+		mockProvider := mocks.NewMockProvider(t)
+
+		mockProvider.EXPECT().Name().Return("mock-provider")
+		mockProvider.EXPECT().Start(mock.Anything, mock.Anything).Return(nil)
+		mockProvider.EXPECT().Events().Return((<-chan ports.Event)(eventChan))
+		mockProvider.EXPECT().Snapshot().Return([]ports.Peer{}).Maybe()
+
+		err := manager.Add(mockProvider)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		err = manager.Start(ctx, "127.0.0.1", 8080, 9080)
+		require.NoError(t, err)
+
+		_, unsubStalled := manager.Subscribe()
+		activeSub, unsubActive := manager.Subscribe()
+
+		var receivedMu sync.Mutex
+		received := make([]string, 0, 11)
+
+		done := make(chan struct{})
+
+		go func() {
+			for i := 0; i < 11; i++ {
+				select {
+				case evt := <-activeSub:
+					receivedMu.Lock()
+					received = append(received, evt.Peer.ID)
+					receivedMu.Unlock()
+					if len(received) == 11 {
+						close(done)
+					}
+				case <-time.After(2 * time.Second):
+					return
+				}
+			}
+		}()
+
+		for i := 0; i < 11; i++ {
+			peer := ports.Peer{ID: fmt.Sprintf("peer-%d", i)}
+			eventChan <- ports.Event{Type: ports.PeerAdded, Peer: peer}
+		}
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for active subscriber to receive events")
+		}
+
+		receivedMu.Lock()
+		assert.Len(t, received, 11)
+		receivedMu.Unlock()
+
+		require.Eventually(t, func() bool {
+			manager.subscribersMu.RLock()
+			defer manager.subscribersMu.RUnlock()
+			return len(manager.subscribers) == 1
+		}, time.Second, 10*time.Millisecond)
+
+		unsubStalled()
+		unsubActive()
+
+		mockProvider.EXPECT().Stop().Return(nil)
+		err = manager.Stop()
+		assert.NoError(t, err)
+	})
+
+	t.Run("ManagerContinuesBroadcastAfterSubscriberChannelClosed", func(t *testing.T) {
+		metadata.ResetGlobalBootstrapMetadata()
+		logger := slog.Default()
+		manager := NewManager("test-node-closed", logger)
+
+		manager.ctx, _ = context.WithCancel(context.Background())
+		require.NotNil(t, manager.ctx)
+
+		sub1, unsub1 := manager.Subscribe()
+		sub2, unsub2 := manager.Subscribe()
+
+		manager.subscribersMu.RLock()
+		var rawSub1 chan ports.Event
+		var rawSub2 chan ports.Event
+		for _, ch := range manager.subscribers {
+			switch reflect.ValueOf(ch).Pointer() {
+			case reflect.ValueOf(sub1).Pointer():
+				rawSub1 = ch
+			case reflect.ValueOf(sub2).Pointer():
+				rawSub2 = ch
+			}
+		}
+		manager.subscribersMu.RUnlock()
+
+		require.NotNil(t, rawSub1)
+		require.Equal(t, reflect.ValueOf(sub1).Pointer(), reflect.ValueOf(rawSub1).Pointer())
+		require.NotNil(t, rawSub2)
+		require.Equal(t, reflect.ValueOf(sub2).Pointer(), reflect.ValueOf(rawSub2).Pointer())
+
+		closeSubscriberChannel(rawSub1)
+
+		manager.subscribersMu.RLock()
+		require.Len(t, manager.subscribers, 2)
+		manager.subscribersMu.RUnlock()
+
+		peer := ports.Peer{ID: "peer-after-close"}
+		manager.broadcastEvent(ports.Event{Type: ports.PeerAdded, Peer: peer})
+
+		select {
+		case evt, ok := <-rawSub2:
+			require.True(t, ok, "second subscriber channel closed prematurely")
+			assert.Equal(t, peer.ID, evt.Peer.ID)
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timed out waiting for second subscriber")
+		}
+
+		manager.subscribersMu.RLock()
+		assert.Len(t, manager.subscribers, 1)
+		manager.subscribersMu.RUnlock()
+
+		unsub1()
+		unsub2()
+	})
+
 	t.Run("ManagerStopCanBeCalledMultipleTimes", func(t *testing.T) {
 		metadata.ResetGlobalBootstrapMetadata()
 		logger := slog.Default()
@@ -340,4 +472,17 @@ func TestDiscoveryManagerWithMockedProviders(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	})
+}
+
+func TestSendToSubscriberRecover(t *testing.T) {
+	logger := slog.Default()
+	manager := NewManager("test-node-send", logger)
+	manager.ctx, _ = context.WithCancel(context.Background())
+
+	ch := make(chan ports.Event)
+	close(ch)
+
+	cont, prune := manager.sendToSubscriber(0, ch, ports.Event{})
+	assert.True(t, cont)
+	assert.True(t, prune)
 }

--- a/internal/core/manager.go
+++ b/internal/core/manager.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -796,11 +797,54 @@ func (m *Manager) waitForDiscovery(ctx context.Context, timeout time.Duration) (
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	<-timeoutCtx.Done()
-
 	peers := m.discovery.GetPeers()
-	m.logger.Info("discovery phase complete", "peers_found", len(peers))
-	return peers, nil
+	if len(peers) > 0 {
+		m.logger.Info("discovery phase complete", "peers_found", len(peers), "reason", "initial_snapshot")
+		return peers, nil
+	}
+
+	events, unsubscribe := m.discovery.Subscribe()
+	defer unsubscribe()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			if err := timeoutCtx.Err(); err != nil {
+				if errors.Is(err, context.Canceled) && ctx.Err() != nil {
+					return nil, fmt.Errorf("discovery wait aborted: %w", err)
+				}
+				if errors.Is(err, context.DeadlineExceeded) {
+					peers = m.discovery.GetPeers()
+					m.logger.Info("discovery phase complete", "peers_found", len(peers), "reason", "timeout")
+					return peers, nil
+				}
+				return nil, fmt.Errorf("discovery wait aborted: %w", err)
+			}
+			peers = m.discovery.GetPeers()
+			m.logger.Info("discovery phase complete", "peers_found", len(peers), "reason", "timeout")
+			return peers, nil
+		case _, ok := <-events:
+			if !ok {
+				peers = m.discovery.GetPeers()
+				m.logger.Info("discovery phase complete", "peers_found", len(peers), "reason", "events_closed")
+				return peers, nil
+			}
+			peers = m.discovery.GetPeers()
+			if len(peers) > 0 {
+				m.logger.Info("discovery phase complete", "peers_found", len(peers), "reason", "event")
+				return peers, nil
+			}
+		case <-ticker.C:
+			peers = m.discovery.GetPeers()
+			if len(peers) > 0 {
+				m.logger.Info("discovery phase complete", "peers_found", len(peers), "reason", "tick")
+				return peers, nil
+			}
+		}
+	}
 }
 
 type WorkflowTrigger struct {
@@ -1167,7 +1211,8 @@ func (m *Manager) watchForSeniorPeers() {
 
 	m.logger.Info("starting senior peer detection for provisional leader")
 
-	discoveryEvents := m.discovery.Events()
+	discoveryEvents, unsubscribe := m.discovery.Subscribe()
+	defer unsubscribe()
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 

--- a/internal/core/manager.go
+++ b/internal/core/manager.go
@@ -117,6 +117,8 @@ type ClusterMetrics struct {
 	NodesExecuted      int `json:"nodes_executed"`
 }
 
+var ErrDiscoveryStopped = errors.New("discovery stopped before finding any peers")
+
 type ClusterInfo struct {
 	NodeID   string         `json:"node_id"`
 	Status   string         `json:"status"`
@@ -829,6 +831,9 @@ func (m *Manager) waitForDiscovery(ctx context.Context, timeout time.Duration) (
 		case _, ok := <-events:
 			if !ok {
 				peers = m.discovery.GetPeers()
+				if len(peers) == 0 {
+					return nil, fmt.Errorf("discovery stopped before peers found: %w", ErrDiscoveryStopped)
+				}
 				m.logger.Info("discovery phase complete", "peers_found", len(peers), "reason", "events_closed")
 				return peers, nil
 			}

--- a/internal/core/manager_discovery_test.go
+++ b/internal/core/manager_discovery_test.go
@@ -1,0 +1,155 @@
+package core
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/eleven-am/graft/internal/adapters/discovery"
+	"github.com/eleven-am/graft/internal/ports"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testDiscoveryProvider struct {
+	peers  []ports.Peer
+	events chan ports.Event
+}
+
+func newTestDiscoveryProvider() *testDiscoveryProvider {
+	return &testDiscoveryProvider{
+		events: make(chan ports.Event, 10),
+	}
+}
+
+func (p *testDiscoveryProvider) Start(ctx context.Context, announce ports.NodeInfo) error {
+	return nil
+}
+
+func (p *testDiscoveryProvider) Stop() error {
+	close(p.events)
+	return nil
+}
+
+func (p *testDiscoveryProvider) Snapshot() []ports.Peer {
+	return append([]ports.Peer(nil), p.peers...)
+}
+
+func (p *testDiscoveryProvider) Events() <-chan ports.Event {
+	return p.events
+}
+
+func (p *testDiscoveryProvider) Name() string {
+	return "test"
+}
+
+func (p *testDiscoveryProvider) setPeers(peers []ports.Peer) {
+	p.peers = append([]ports.Peer(nil), peers...)
+}
+
+func (p *testDiscoveryProvider) emit(event ports.Event) {
+	p.events <- event
+}
+
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestManagerWaitForDiscovery(t *testing.T) {
+	logger := newTestLogger()
+
+	t.Run("returns immediately when peers already known", func(t *testing.T) {
+		provider := newTestDiscoveryProvider()
+		peer := ports.Peer{ID: "peer-initial", Address: "127.0.0.1", Port: 8080}
+		provider.setPeers([]ports.Peer{peer})
+
+		manager := discovery.NewManager("test-node", logger)
+		require.NoError(t, manager.Add(provider))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		require.NoError(t, manager.Start(ctx, "127.0.0.1", 8080, 9080))
+
+		coreManager := &Manager{logger: logger, discovery: manager}
+		peers, err := coreManager.waitForDiscovery(ctx, time.Second)
+		require.NoError(t, err)
+		assert.Len(t, peers, 1)
+		assert.Equal(t, peer.ID, peers[0].ID)
+
+		assert.NoError(t, manager.Stop())
+	})
+
+	t.Run("returns when discovery emits peers", func(t *testing.T) {
+		provider := newTestDiscoveryProvider()
+
+		manager := discovery.NewManager("test-node", logger)
+		require.NoError(t, manager.Add(provider))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		require.NoError(t, manager.Start(ctx, "127.0.0.1", 8080, 9080))
+
+		coreManager := &Manager{logger: logger, discovery: manager}
+
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			peer := ports.Peer{ID: "peer-event", Address: "127.0.0.1", Port: 8081}
+			provider.setPeers([]ports.Peer{peer})
+			provider.emit(ports.Event{Type: ports.PeerAdded, Peer: peer})
+		}()
+
+		peers, err := coreManager.waitForDiscovery(ctx, time.Second)
+		require.NoError(t, err)
+		assert.Len(t, peers, 1)
+		assert.Equal(t, "peer-event", peers[0].ID)
+
+		assert.NoError(t, manager.Stop())
+	})
+
+	t.Run("returns error when context cancelled", func(t *testing.T) {
+		provider := newTestDiscoveryProvider()
+
+		manager := discovery.NewManager("test-node", logger)
+		require.NoError(t, manager.Add(provider))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		require.NoError(t, manager.Start(ctx, "127.0.0.1", 8080, 9080))
+
+		coreManager := &Manager{logger: logger, discovery: manager}
+
+		cancel()
+
+		peers, err := coreManager.waitForDiscovery(ctx, time.Second)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Nil(t, peers)
+
+		assert.NoError(t, manager.Stop())
+	})
+
+	t.Run("returns empty result when timeout exceeded", func(t *testing.T) {
+		provider := newTestDiscoveryProvider()
+
+		manager := discovery.NewManager("test-node", logger)
+		require.NoError(t, manager.Add(provider))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		require.NoError(t, manager.Start(ctx, "127.0.0.1", 8080, 9080))
+
+		coreManager := &Manager{logger: logger, discovery: manager}
+
+		peers, err := coreManager.waitForDiscovery(ctx, 50*time.Millisecond)
+		assert.NoError(t, err)
+		assert.Len(t, peers, 0)
+
+		assert.NoError(t, manager.Stop())
+	})
+}


### PR DESCRIPTION
## Summary
- add a subscription/broadcast mechanism to the discovery manager so multiple consumers receive every event and shutdown is race-free
- make the core manager wait for discovery events or cancellation instead of always sleeping, while distinguishing cancellation from timeouts
- add targeted tests for the new discovery subscription behaviour and the updated wait logic

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ffd1521a1c83269c45381b1fb87536